### PR TITLE
Add retain flag for hass registration topics.

### DIFF
--- a/Firmware/Hugo_MqttTrigger/hass_register.ino
+++ b/Firmware/Hugo_MqttTrigger/hass_register.ino
@@ -19,7 +19,7 @@ void sendConfig(StaticJsonDocument<512>& payload, String configTopic) {
   char output[512];
   serializeJson(payload, output);
   Serial.println(output);
-  if (client.publish(configTopic.c_str(), output)) {
+  if (client.publish(configTopic.c_str(), output, true)) {
     Serial.print("Discovery data sent.");
   } else {
     Serial.print("Failed to send discovery data, error = ");


### PR DESCRIPTION
Add retain flag for Home Assistant MQTT registration topics to keep device config across HA restarts.
Closing #23.